### PR TITLE
Remove code that breaks rendering of forms for models with an array field

### DIFF
--- a/forms/fields.js
+++ b/forms/fields.js
@@ -517,7 +517,6 @@ var ListField_ = exports.ListField = BaseField.extend({
             field.errors = errors[field_name] || [];
             if (field_name === '__self__') {
                 field.set(value);
-                field.
                 field.render(res);
             } else {
                 field.set(value ? self.deep_read(value, field_name) : null);


### PR DESCRIPTION
Cleaned up this nasty bit which completely breaks form screen for models with an array field in the latest version of formage: 

```
TypeError: Cannot call method 'render' of undefined
    at render_field (C:\projects\<project>\node_modules\formage-admin\forms\fields.js:521:23)
    at render_fields (C:\projects\<project>\node_modules\formage-admin\forms\fields.js:508:21)
    at Class.exports.ListField.BaseField.extend.render_list_item (C:\projects\<project>\node_modules\formage-admin\forms\fields.js:542:13)
    at render_template (C:\projects\<project>\node_modules\formage-admin\forms\fields.js:461:18)
    at Class.exports.ListWidget.Widget.extend.render (C:\projects\<project>\node_modules\formage-admin\forms\widgets.js:315:9)
    at Class.exports.ListField.BaseField.extend.render (C:\projects\<project>\node_modules\formage-admin\forms\fields.js:471:21)
    at Class.exports.BaseField.Class.extend.render_with_label (C:\projects\<project>\node_modules\formage-admin\forms\fields.js:91:14)
    at render_fields (C:\projects\<project>\node_modules\formage-admin\forms\forms.js:210:49)
    at Class.exports.BaseForm.Class.extend.render (C:\projects\<project>\node_modules\formage-admin\forms\forms.js:239:13)
    at C:\projects\<project>\node_modules\formage-admin\forms\forms.js:250:18
```
