### PR TITLE
Support for multiple occurrences of __value__ in search string

### DIFF
--- a/routes.js
+++ b/routes.js
@@ -289,7 +289,7 @@ function getSearchQuery(model, searchValue) {
         }).join('||');
     }
     else {
-        return searchRule.replace('__value__', valueRegex);
+        return searchRule.replace(/__value__/g, valueRegex);
     }
 }
 


### PR DESCRIPTION
It should be possible to use `__value__` several times in the search string in order to build complex search queries.
