### PR TITLE
Catch errors thrown from validation

### DIFF
--- a/lib/forms/AdminForm.js
+++ b/lib/forms/AdminForm.js
@@ -139,6 +139,7 @@ AdminForm.prototype.validate = function validate() {
         });
         return pi;
     });
+
     return p;
 };
 
@@ -156,6 +157,9 @@ AdminForm.prototype.save = function save(callback) {
             } else {
                 p.reject(new Error("not valid"));
             }
+        },
+        function (err) {
+            p.reject(err)
         }
     );
     return p;


### PR DESCRIPTION
Without this, errors thrown from validate() were being dropped on the floor.
