### PR TITLE
Ensures that label and ID are set on the response sent to the related model modal box after saving

### DIFF
--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -211,7 +211,10 @@ module.exports = function (registry) {
                     upsertDocument(req).then(
                         function (form) {
                             res._debug_form = form;
-                            res.json(200, form.instance);
+                            var response = form.instance.toJSON();
+                            response.id = response.id || form.instance._id;
+                            response.label = response.label || form.instance.name || form.instance.title || form.instance.toString();
+                            res.json(200, response);
                         }
                     ).end(
                         function (err) {


### PR DESCRIPTION
If I'm editing a model and try to create a related model, depending on the model configuration, the response will not contain `id` or `label` properties (which `document.js` expects). This simply ensures they're set.
