### PR TITLE
Widget limit of 0 is defaulted to 50

### DIFF
--- a/lib/forms/widgets.js
+++ b/lib/forms/widgets.js
@@ -5,7 +5,7 @@ var Class = require('./sji'),
 
 var Widget = exports.Widget = Class.extend({
     init: function (options) {
-        this.limit = options.limit || 50;
+        this.limit = _.isUndefined(options.limit) ? 50 : options.limit;
         this.validators = options.validators;
         this.attrs = _.assign({class: []}, options.attrs);
         this.attrs.class.push(options.required || options.attrs.required ? 'required' : 'optional');


### PR DESCRIPTION
I'd like to be able to set the widget limit to 0 in some circumstances; the current logic would cause a limit of 0 to be overridden with 50.
