### PR TITLE
Fix deprecated use of res.json(status,obj)

### DIFF
--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -113,7 +113,7 @@ module.exports = function (registry) {
                         if (_.isEmpty(depPair)) return res.json(200, []);
                         var deps = depPair[1];
                         var lines = dependencies.depsToLines(deps);
-                        return res.json(200, lines);
+                        return res.send(200).json(lines);
                     });
                 },
 
@@ -173,12 +173,12 @@ module.exports = function (registry) {
                             return response;
                         }
                     ).then(
-                        function (response) {
-                            res.json(200, response);
+                      function (response) {
+                        res.send(200)json(response);
                         },
                         function (err) {
                             err.form = res._debug_form;
-                            res.json(422, err);
+                            res.send(422).json(err);
                         }
                     ).end();
                 },
@@ -197,8 +197,8 @@ module.exports = function (registry) {
                         ]);
                         modelConfig.model.update({_id: id}, {'$set': set_dict}, cb);
                     }, function (err) {
-                        if (err) throw err;
-                        res.json({"collection": modelName});
+                      if (err) throw err;
+                      res.send(200).json({"collection": modelName});
                     });
                 },
 
@@ -206,9 +206,9 @@ module.exports = function (registry) {
                 actionDocuments: function actionDocuments(req, res) {
                     var modelName = req.params.modelName,
                         actionId = req.params['actionId'],
-                        ids = req.body.ids,
+                        ids = ('ids' in req.body) ? req.body.ids : req.body['ids[]'],
                         model = registry.models[modelName];
-
+                    ids = (typeof(ids) === 'string') ? [ ids ] : ids;
                     if (!req.admin_user.hasPermissions(modelName, 'update'))
                         throw new Error('unauthorized');
 
@@ -216,9 +216,9 @@ module.exports = function (registry) {
                     if (!action)
                         throw new TypeError('Could not find action with id=' + actionId);
 
-                    return action.func.call(model, req.admin_user, ids, function (err, message) {
-                        if (err) return res.json(422, { error: err.message });
-                        return res.json(message || 'All is good.');
+                  return action.func.call(model, req.admin_user, ids, function (err, message) {
+                    if (err) return res.send(422).json({ error: err.message });
+                    return res.send(200).json(message || 'All is good.');
                     });
                 }
             },


### PR DESCRIPTION
The favored way method is res.send(status).json(obj).