### PR TITLE
 Fix deprecated use of res.json(status,obj)

### DIFF
--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -110,10 +110,10 @@ module.exports = function (registry) {
 
                     dependencies.check(models, modelName, id, function (err, depPair) {
                         if (err) throw err;
-                        if (_.isEmpty(depPair)) return res.json(200, []);
+                      if (_.isEmpty(depPair)) return res.send(200).json([]);
                         var deps = depPair[1];
                         var lines = dependencies.depsToLines(deps);
-                        return res.json(200, lines);
+                      return res.send(200).json(lines);
                     });
                 },
 
@@ -174,11 +174,11 @@ module.exports = function (registry) {
                         }
                     ).then(
                         function (response) {
-                            res.json(200, response);
+                          res.send(200).json(response);
                         },
                         function (err) {
-                            err.form = res._debug_form;
-                            res.json(422, err);
+                          err.form = res._debug_form;
+                          res.send(422).json(err);
                         }
                     ).end();
                 },
@@ -197,8 +197,8 @@ module.exports = function (registry) {
                         ]);
                         modelConfig.model.update({_id: id}, {'$set': set_dict}, cb);
                     }, function (err) {
-                        if (err) throw err;
-                        res.json({"collection": modelName});
+                      if (err) throw err;
+                      res.send(200).json({"collection": modelName});
                     });
                 },
 
@@ -217,8 +217,8 @@ module.exports = function (registry) {
                         throw new TypeError('Could not find action with id=' + actionId);
 
                     return action.func.call(model, req.admin_user, ids, function (err, message) {
-                        if (err) return res.json(422, { error: err.message });
-                        return res.json(message || 'All is good.');
+                        if (err) return res.send(422).json({ error: err.message });
+                        return res.send(200).json(message || 'All is good.');
                     });
                 }
             },


### PR DESCRIPTION
The favored way method is res.send(status).json(obj).